### PR TITLE
Fix task file naming and empty task bug

### DIFF
--- a/task_manager.py
+++ b/task_manager.py
@@ -2,6 +2,9 @@ tasks = []
 
 def add_task():
     task = input("Enter task: ")
+    if not task.strip():
+        print("Task description cannot be empty.")
+        return
     tasks.append(task)
     print("Task added successfully!")
 


### PR DESCRIPTION
## Summary
- rename `file_manager.py` to `task_manager.py` so the file matches README instructions
- disallow adding empty tasks to the list

## Testing
- `python -m py_compile task_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6858e9926394832587ef8d3ce32775bc